### PR TITLE
Fix unnecessary awaits in form routes

### DIFF
--- a/src/processes/api/formRoutes.ts
+++ b/src/processes/api/formRoutes.ts
@@ -46,7 +46,7 @@ const handleFormSubmit = async (req: Request, res: Response): Promise<void> => {
       createdAt: new Date(),
     };
 
-    await formStore.add(formData);
+    formStore.add(formData);
 
     const response: FormResponse = {
       success: true,
@@ -65,7 +65,7 @@ const handleFormSubmit = async (req: Request, res: Response): Promise<void> => {
 };
 
 const handleFormCount = async (_req: Request, res: Response): Promise<void> => {
-  const count = await formStore.count();
+  const count = formStore.count();
   res.json({ count });
 };
 


### PR DESCRIPTION
## Summary
- remove `await` from synchronous `formStore` operations

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f498e4600832c93a3d567fdcc44c2